### PR TITLE
[FEAT] 웹 사이트에 vercel Speed Insights 플러그인 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@mui/styles": "^5.4.4",
         "@stripe/react-stripe-js": "^1.4.1",
         "@stripe/stripe-js": "^1.16.0",
+        "@vercel/analytics": "^1.2.2",
         "@wavesurfer/react": "^1.0.5",
         "aos": "^2.3.4",
         "axios": "^1.6.8",
@@ -4942,6 +4943,26 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.2.2.tgz",
+      "integrity": "sha512-X0rctVWkQV1e5Y300ehVNqpOfSOufo7ieA5PIdna8yX/U7Vjz0GFsGf4qvAhxV02uQ2CVt7GYcrFfddXXK2Y4A==",
+      "dependencies": {
+        "server-only": "^0.0.1"
+      },
+      "peerDependencies": {
+        "next": ">= 13",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@wavesurfer/react": {
       "version": "1.0.5",
@@ -15506,6 +15527,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -21366,6 +21392,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "@vercel/analytics": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.2.2.tgz",
+      "integrity": "sha512-X0rctVWkQV1e5Y300ehVNqpOfSOufo7ieA5PIdna8yX/U7Vjz0GFsGf4qvAhxV02uQ2CVt7GYcrFfddXXK2Y4A==",
+      "requires": {
+        "server-only": "^0.0.1"
+      }
     },
     "@wavesurfer/react": {
       "version": "1.0.5",
@@ -28885,6 +28919,11 @@
         "parseurl": "~1.3.3",
         "send": "0.18.0"
       }
+    },
+    "server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
     },
     "set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@mui/styles": "^5.4.4",
     "@stripe/react-stripe-js": "^1.4.1",
     "@stripe/stripe-js": "^1.16.0",
+    "@vercel/analytics": "^1.2.2",
     "@wavesurfer/react": "^1.0.5",
     "aos": "^2.3.4",
     "axios": "^1.6.8",

--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,14 @@ import ReactDOM from "react-dom";
 import App from "./App";
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import {QueryClientProvider, QueryClient} from "react-query";
+import { Analytics } from "@vercel/analytics/react"
 
 const queryClient = new QueryClient();
 
 ReactDOM.render(
   <QueryClientProvider client={queryClient}>
     <App />
+    <Analytics />
   </QueryClientProvider>,
   document.getElementById("root")
 );


### PR DESCRIPTION
### 🧐 어떤 것을 변경했어요~?
vercel에서 웹사이트 속도를 측정해주는 플러그인을 추가합니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
1. 프로젝트에 npm i @vercel/speed-insights 명령어로 package.json에 의존성 추가하기
2.  해당 컴포넌트를 react render 함수에 추가하기

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
배포를 해야지 진가가 발휘된다고 생각합니다.
