### PR TITLE
[FEAT] 효과음 세부 페이지 구현

### DIFF
--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -168,6 +168,7 @@ function Main(props) {
             soundName: soundEffect.soundEffectName,
             soundTagList: soundEffect.soundEffectTags,
             soundURL: soundEffect.soundEffectTypes[0].url,
+            soundType: soundEffect.soundEffectTypes[0].soundEffectTypeName,
             soundLength: soundEffect.soundEffectTypes[0].length,
             soundDescription: soundEffect.description,
             soundCreateBy: soundEffect.createBy,

--- a/src/logged_out/components/Routing.js
+++ b/src/logged_out/components/Routing.js
@@ -20,6 +20,7 @@ function Routing(props) {
           key={post.soundName}
           src={post.soundURL}
           date={post.soundCreateAt}
+          tagList={post.soundTagList}
           content={post.soundContents}
           otherArticles={soundListPosts.filter(
             (soundListPost) => soundListPost.soundId !== post.soundId

--- a/src/logged_out/components/Routing.js
+++ b/src/logged_out/components/Routing.js
@@ -21,6 +21,7 @@ function Routing(props) {
           src={post.soundURL}
           date={post.soundCreateAt}
           tagList={post.soundTagList}
+          fileExtension={post.soundType}
           content={post.soundContents}
           otherArticles={soundListPosts.filter(
             (soundListPost) => soundListPost.soundId !== post.soundId

--- a/src/logged_out/components/Routing.js
+++ b/src/logged_out/components/Routing.js
@@ -23,9 +23,7 @@ function Routing(props) {
           tagList={post.soundTagList}
           fileExtension={post.soundType}
           content={post.soundContents}
-          otherArticles={soundListPosts.filter(
-            (soundListPost) => soundListPost.soundId !== post.soundId
-          )}
+          id={post.soundId}
         />
       ))}
       <PropsRoute

--- a/src/logged_out/components/home/WaveSurferComponent.js
+++ b/src/logged_out/components/home/WaveSurferComponent.js
@@ -39,7 +39,7 @@ const styles = () => ({
 });
 
 const WaveSurferComponent = (props) => {
-  const {classes, audioURL} = props
+  const {classes, audioURL, setCurrentTime} = props
   const waveform = useRef(null);
   const wavesurfer = useRef(null);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -68,8 +68,14 @@ const WaveSurferComponent = (props) => {
         wavesurfer.current.pause();
         setIsPlaying(false);
       });
+
+      wavesurfer.current.on('audioprocess', () => {
+        if (setCurrentTime) {
+          setCurrentTime(wavesurfer.current.getCurrentTime());
+        }
+      });
     }
-  },[audioURL])
+  },[audioURL, setCurrentTime])
 
   const buttonClick = (event) => {
     event.preventDefault();

--- a/src/logged_out/components/home/WaveSurferComponent.js
+++ b/src/logged_out/components/home/WaveSurferComponent.js
@@ -39,7 +39,7 @@ const styles = () => ({
 });
 
 const WaveSurferComponent = (props) => {
-  const {classes, audioURL, setCurrentTime} = props
+  const {classes, audioURL, setCurrentTime, setDuration} = props
   const waveform = useRef(null);
   const wavesurfer = useRef(null);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -61,6 +61,9 @@ const WaveSurferComponent = (props) => {
       wavesurfer.current.on('ready', () => {
         wavesurfer.current.setVolume(0.5);
         wavesurfer.current.pause();
+        if (setDuration){
+          setDuration(wavesurfer.current.getDuration());
+        }
       });
 
       wavesurfer.current.on("finish", () => {
@@ -75,7 +78,7 @@ const WaveSurferComponent = (props) => {
         }
       });
     }
-  },[audioURL, setCurrentTime])
+  },[audioURL, setCurrentTime, setDuration])
 
   const buttonClick = (event) => {
     event.preventDefault();

--- a/src/logged_out/components/soundList/SoundDetailPaper.js
+++ b/src/logged_out/components/soundList/SoundDetailPaper.js
@@ -1,0 +1,39 @@
+import withStyles from "@mui/styles/withStyles";
+import {Paper, Stack, Typography} from "@mui/material";
+import React from "react";
+
+
+const styles = (theme) => ({
+  itemPaperContainer:{
+    backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+    ...theme.typography.body2,
+    padding: theme.spacing(1),
+    textAlign: 'center',
+    width: '100%',
+    height: '100%',
+  },
+  textTitle:{
+    color: theme.palette.text.primary,
+  },
+  textDefault:{
+    color: theme.palette.text.secondary,
+  },
+})
+
+function SoundDetailPaper(props) {
+  const {classes, title, value} = props;
+  return (
+    <Paper className={classes.itemPaperContainer}>
+      <Stack>
+        <Typography variant="subtitle2" gutterBottom className={classes.textTitle}>
+          {title}
+        </Typography>
+        <Typography variant="body1" className={classes.textDefault}>
+          {value}
+        </Typography>
+      </Stack>
+    </Paper>
+  )
+}
+
+export default withStyles(styles, { withTheme: true })(SoundDetailPaper);

--- a/src/logged_out/components/soundList/SoundListPost.js
+++ b/src/logged_out/components/soundList/SoundListPost.js
@@ -2,11 +2,10 @@ import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import format from "date-fns/format";
-import { Grid, Typography, Card, Box } from "@mui/material";
+import {Grid, Typography, Card, Box, Chip} from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
 import SoundListCard from "./SoundListCard";
 import ShareButton from "../../../shared/components/ShareButton";
-// import ZoomImage from "../../../shared/components/ZoomImage";
 import smoothScrollTop from "../../../shared/functions/smoothScrollTop";
 import WaveSurferComponent from "../home/WaveSurferComponent";
 
@@ -31,10 +30,17 @@ const styles = (theme) => ({
   card: {
     boxShadow: theme.shadows[4],
   },
+  chip: {
+    // backgroundColor: theme.palette.secondary.main,
+    // color: "white",
+    color: theme.palette.secondary.main,
+    marginRight: "8px",
+    marginBottom: "8px",
+  },
 });
 
 function SoundListPost(props) {
-  const { classes, date, title, src, content, otherArticles } = props;
+  const { classes, date, title, src, content, tagList, otherArticles } = props;
 
   useEffect(() => {
     document.title = `WaVer - ${title}`;
@@ -53,18 +59,39 @@ function SoundListPost(props) {
         <Grid container spacing={5}>
           <Grid item md={9}>
             <Card className={classes.card}>
+              <Box sx={{border: '2px solid black'}}>
+                <WaveSurferComponent audioURL={src}/>
+              </Box>
               <Box pt={3} pr={3} pl={3} pb={2}>
                 <Typography variant="h4">
                   <b>{title}</b>
                 </Typography>
-                <Typography variant="body1" color="textSecondary">
-                  {format(new Date(date * 1000), "PPP", {
-                    awareOfUnicodeTokens: true,
+                <Box sx={{display: 'flex'}}>
+                  <Typography variant="body1" color="textSecondary" sx={{padding: '0px 5px'}}>
+                    Downloads 133,333
+                  </Typography>
+                  <Typography variant="body1">
+                    |
+                  </Typography>
+                  <Typography variant="body1" color="textSecondary" sx={{padding: '0px 5px'}}>
+                    {format(new Date(date * 1000), "PPP", {
+                      awareOfUnicodeTokens: true,
+                    })}
+                  </Typography>
+                </Box>
+                <Box sx={{margin: '5px 0'}}>
+                  {tagList && tagList.map(({tagId, tagName}) => {
+                    return (
+                      <Chip
+                        label={tagName}
+                        variant="outlined"
+                        size="small"
+                        className={classes.chip}
+                        key={tagId}
+                      />);
                   })}
-                </Typography>
+                </Box>
               </Box>
-              {/*<ZoomImage className={classes.img} src={src} alt="" />*/}
-              <WaveSurferComponent audioURL={src}/>
               <Box p={3}>
                 {content}
                 <Box pt={2}>

--- a/src/logged_out/components/soundList/SoundListPost.js
+++ b/src/logged_out/components/soundList/SoundListPost.js
@@ -66,6 +66,7 @@ const styles = (theme) => ({
 function SoundListPost(props) {
   const { classes, date, title, src, content, tagList, fileExtension, id } = props;
   const [relativeSoundEffects, setRelativeSoundEffects] = useState([])
+  const [currentTime, setCurrentTime] = useState(0);
 
   useEffect(() => {
     document.title = `AuLo - ${title}`;
@@ -155,8 +156,16 @@ function SoundListPost(props) {
         <Grid container spacing={5}>
           <Grid item md={9}>
             <Card className={classes.card}>
-              <Box sx={{border: '2px solid black'}}>
-                <WaveSurferComponent audioURL={src}/>
+              <Box pr={3} pl={3} sx={{border: '2px solid black'}}>
+                <WaveSurferComponent audioURL={src} setCurrentTime={setCurrentTime}/>
+              </Box>
+              <Box pt={1} pr={3} pl={3} className={classes.titleContainer}>
+                <Typography>
+                  {currentTime}
+                </Typography>
+                <Typography>
+                  {currentTime}
+                </Typography>
               </Box>
               <Box pt={3} pr={3} pl={3} pb={2} className={classes.titleContainer}>
                 <Box>

--- a/src/logged_out/components/soundList/SoundListPost.js
+++ b/src/logged_out/components/soundList/SoundListPost.js
@@ -2,12 +2,13 @@ import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import format from "date-fns/format";
-import {Grid, Typography, Card, Box, Chip} from "@mui/material";
+import {Grid, Typography, Card, Box, Chip, Button} from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
 import SoundListCard from "./SoundListCard";
 import ShareButton from "../../../shared/components/ShareButton";
 import smoothScrollTop from "../../../shared/functions/smoothScrollTop";
 import WaveSurferComponent from "../home/WaveSurferComponent";
+import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 
 const styles = (theme) => ({
   blogContentWrapper: {
@@ -37,15 +38,48 @@ const styles = (theme) => ({
     marginRight: "8px",
     marginBottom: "8px",
   },
+  titleContainer:{
+    border: '1px red solid',
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  titleButtonContainer:{
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+  },
 });
 
 function SoundListPost(props) {
-  const { classes, date, title, src, content, tagList, otherArticles } = props;
+  const { classes, date, title, src, content, tagList, fileExtension, otherArticles } = props;
 
   useEffect(() => {
-    document.title = `WaVer - ${title}`;
+    document.title = `AuLo - ${title}`;
     smoothScrollTop();
   }, [title]);
+
+  const handleDownload = () => {
+    fetch(src, { method: 'GET' })
+      .then(res => {
+        return res.blob();
+      })
+      .then(blob => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${title}.${fileExtension}`;
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(_ => {
+          window.URL.revokeObjectURL(url);
+        }, 60000);
+        a.remove();
+      })
+      .catch(err => {
+        console.error('err: ', err);
+      });
+  };
 
   const sliceOtherArticles = otherArticles.slice(0, 5) // up to 5 element
 
@@ -62,34 +96,48 @@ function SoundListPost(props) {
               <Box sx={{border: '2px solid black'}}>
                 <WaveSurferComponent audioURL={src}/>
               </Box>
-              <Box pt={3} pr={3} pl={3} pb={2}>
-                <Typography variant="h4">
-                  <b>{title}</b>
-                </Typography>
-                <Box sx={{display: 'flex'}}>
-                  <Typography variant="body1" color="textSecondary" sx={{padding: '0px 5px'}}>
-                    Downloads 133,333
+              <Box pt={3} pr={3} pl={3} pb={2} className={classes.titleContainer}>
+                <Box>
+                  <Typography variant="h4">
+                    <b>{title}</b>
                   </Typography>
-                  <Typography variant="body1">
-                    |
-                  </Typography>
-                  <Typography variant="body1" color="textSecondary" sx={{padding: '0px 5px'}}>
-                    {format(new Date(date * 1000), "PPP", {
-                      awareOfUnicodeTokens: true,
+                  <Box sx={{display: 'flex'}}>
+                    <Typography variant="body1" color="textSecondary" sx={{padding: '0px 5px'}}>
+                      Downloads 133,333
+                    </Typography>
+                    <Typography variant="body1">
+                      |
+                    </Typography>
+                    <Typography variant="body1" color="textSecondary" sx={{padding: '0px 5px'}}>
+                      {format(new Date(date * 1000), "PPP", {
+                        awareOfUnicodeTokens: true,
+                      })}
+                    </Typography>
+                  </Box>
+                  <Box sx={{margin: '5px 0'}}>
+                    {tagList && tagList.map(({tagId, tagName}) => {
+                      return (
+                        <Chip
+                          label={tagName}
+                          variant="outlined"
+                          size="small"
+                          className={classes.chip}
+                          key={tagId}
+                        />);
                     })}
-                  </Typography>
+                  </Box>
                 </Box>
-                <Box sx={{margin: '5px 0'}}>
-                  {tagList && tagList.map(({tagId, tagName}) => {
-                    return (
-                      <Chip
-                        label={tagName}
-                        variant="outlined"
-                        size="small"
-                        className={classes.chip}
-                        key={tagId}
-                      />);
-                  })}
+                <Box className={classes.titleButtonContainer}>
+                  <Button
+                    component="label"
+                    role={undefined}
+                    variant="contained"
+                    tabIndex={-1}
+                    startIcon={<CloudDownloadIcon />}
+                    onClick={handleDownload}
+                  >
+                    Download
+                  </Button>
                 </Box>
               </Box>
               <Box p={3}>

--- a/src/logged_out/components/soundList/SoundListPost.js
+++ b/src/logged_out/components/soundList/SoundListPost.js
@@ -67,6 +67,7 @@ function SoundListPost(props) {
   const { classes, date, title, src, content, tagList, fileExtension, id } = props;
   const [relativeSoundEffects, setRelativeSoundEffects] = useState([])
   const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
 
   useEffect(() => {
     document.title = `AuLo - ${title}`;
@@ -156,15 +157,19 @@ function SoundListPost(props) {
         <Grid container spacing={5}>
           <Grid item md={9}>
             <Card className={classes.card}>
-              <Box pr={3} pl={3} sx={{border: '2px solid black'}}>
-                <WaveSurferComponent audioURL={src} setCurrentTime={setCurrentTime}/>
+              <Box sx={{border: '2px solid black'}}>
+                <WaveSurferComponent
+                  audioURL={src}
+                  setCurrentTime={setCurrentTime}
+                  setDuration={setDuration}
+                />
               </Box>
               <Box pt={1} pr={3} pl={3} className={classes.titleContainer}>
                 <Typography>
                   {currentTime}
                 </Typography>
                 <Typography>
-                  {currentTime}
+                  {duration}
                 </Typography>
               </Box>
               <Box pt={3} pr={3} pl={3} pb={2} className={classes.titleContainer}>

--- a/src/logged_out/components/soundList/SoundListPost.js
+++ b/src/logged_out/components/soundList/SoundListPost.js
@@ -39,7 +39,6 @@ const styles = (theme) => ({
     marginBottom: "8px",
   },
   titleContainer:{
-    border: '1px red solid',
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between'
@@ -168,9 +167,9 @@ function SoundListPost(props) {
           </Grid>
           <Grid item md={3}>
             <Typography variant="h6" paragraph>
-              Other articles
+              Relative Sounds
             </Typography>
-            {sliceOtherArticles.map((blogPost) => (
+            {sliceOtherArticles.slice(0, 3).map((blogPost) => (
               <Box key={blogPost.soundId} mb={3}>
                 <SoundListCard
                   title={blogPost.soundName}

--- a/src/logged_out/components/soundList/SoundListPost.js
+++ b/src/logged_out/components/soundList/SoundListPost.js
@@ -2,12 +2,13 @@ import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import format from "date-fns/format";
-import {Grid, Typography, Card, Box, Chip, Button, Divider, Stack, Paper} from "@mui/material";
+import {Grid, Typography, Card, Box, Chip, Button, Divider, Stack} from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
 import SoundListCard from "./SoundListCard";
 import smoothScrollTop from "../../../shared/functions/smoothScrollTop";
 import WaveSurferComponent from "../home/WaveSurferComponent";
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
+import SoundDetailPaper from "./SoundDetailPaper";
 
 const styles = (theme) => ({
   blogContentWrapper: {
@@ -58,7 +59,7 @@ const styles = (theme) => ({
   },
   textDefault:{
     color: theme.palette.text.secondary,
-  }
+  },
 });
 
 function SoundListPost(props) {
@@ -157,19 +158,16 @@ function SoundListPost(props) {
                   <Stack
                     direction={{ xs: 'column', sm: 'row' }}
                     spacing={{ xs: 1, sm: 2, md: 4 }}
+                    sx={{width: '100%', height: '100%'}}
+                    justifyContent="space-between"
+                    alignItems="center"
                   >
-                    <Paper className={classes.itemPaperContainer}>
-                      <Stack>
-                        <Typography variant="h6" gutterBottom className={classes.textTitle}>
-                          Type
-                        </Typography>
-                        <Typography className={classes.textDefault}>
-                          Wave
-                        </Typography>
-                      </Stack>
-                    </Paper>
-                    <Paper className={classes.itemPaperContainer}>Item 1</Paper>
-                    <Paper className={classes.itemPaperContainer}>Item 1</Paper>
+                    <SoundDetailPaper title="Type" value="wave" />
+                    <SoundDetailPaper title="Duration" value="00:30:00" />
+                    <SoundDetailPaper title="File Size" value="18.42MB" />
+                    <SoundDetailPaper title="Sample Rate" value="48000.00HZ" />
+                    <SoundDetailPaper title="Bit depth" value="24bit" />
+                    <SoundDetailPaper title="Channels" value="Stereo" />
                   </Stack>
                 </Box>
               </Box>

--- a/src/logged_out/components/soundList/SoundListPost.js
+++ b/src/logged_out/components/soundList/SoundListPost.js
@@ -147,6 +147,20 @@ function SoundListPost(props) {
       });
   };
 
+  // 시간을 hh:mm:ss 형식으로 변환하는 함수
+  const formatTime = (timeInSeconds) => {
+    const hours = Math.floor(timeInSeconds / 3600);
+    const minutes = Math.floor((timeInSeconds % 3600) / 60);
+    const seconds = Math.floor(timeInSeconds % 60);
+
+    // 시, 분, 초를 두 자리수로 표시하고 앞에 0을 붙임
+    const formattedHours = hours.toString().padStart(2, '0');
+    const formattedMinutes = minutes.toString().padStart(2, '0');
+    const formattedSeconds = seconds.toString().padStart(2, '0');
+
+    return `${formattedHours}:${formattedMinutes}:${formattedSeconds}`;
+  };
+
   return (
     <Box
       className={classNames("lg-p-top", classes.wrapper)}
@@ -166,10 +180,10 @@ function SoundListPost(props) {
               </Box>
               <Box pt={1} pr={3} pl={3} className={classes.titleContainer}>
                 <Typography>
-                  {currentTime}
+                  {formatTime(currentTime)}
                 </Typography>
                 <Typography>
-                  {duration}
+                  {formatTime(duration)}
                 </Typography>
               </Box>
               <Box pt={3} pr={3} pl={3} pb={2} className={classes.titleContainer}>

--- a/src/logged_out/components/soundList/SoundListPost.js
+++ b/src/logged_out/components/soundList/SoundListPost.js
@@ -2,10 +2,9 @@ import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import format from "date-fns/format";
-import {Grid, Typography, Card, Box, Chip, Button} from "@mui/material";
+import {Grid, Typography, Card, Box, Chip, Button, Divider, Stack, Paper} from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
 import SoundListCard from "./SoundListCard";
-import ShareButton from "../../../shared/components/ShareButton";
 import smoothScrollTop from "../../../shared/functions/smoothScrollTop";
 import WaveSurferComponent from "../home/WaveSurferComponent";
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
@@ -48,6 +47,18 @@ const styles = (theme) => ({
     flexDirection: 'column',
     justifyContent: 'center',
   },
+  itemPaperContainer:{
+    backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+    ...theme.typography.body2,
+    padding: theme.spacing(1),
+    textAlign: 'center',
+  },
+  textTitle:{
+    color: theme.palette.text.primary,
+  },
+  textDefault:{
+    color: theme.palette.text.secondary,
+  }
 });
 
 function SoundListPost(props) {
@@ -141,26 +152,25 @@ function SoundListPost(props) {
               </Box>
               <Box p={3}>
                 {content}
-                <Box pt={2}>
-                  <Grid spacing={1} container>
-                    {["Facebook", "Twitter", "Reddit", "Tumblr"].map(
-                      (type, index) => (
-                        <Grid item key={index}>
-                          <ShareButton
-                            type={type}
-                            title="React SaaS Template"
-                            description="I found an awesome template for an webapp using React!"
-                            disableElevation
-                            variant="contained"
-                            className="text-white"
-                            classes={{
-                              label: "text-white",
-                            }}
-                          />
-                        </Grid>
-                      )
-                    )}
-                  </Grid>
+                <Divider />
+                <Box pt={2} sx={{display:'flex', justifyContent: 'center'}}>
+                  <Stack
+                    direction={{ xs: 'column', sm: 'row' }}
+                    spacing={{ xs: 1, sm: 2, md: 4 }}
+                  >
+                    <Paper className={classes.itemPaperContainer}>
+                      <Stack>
+                        <Typography variant="h6" gutterBottom className={classes.textTitle}>
+                          Type
+                        </Typography>
+                        <Typography className={classes.textDefault}>
+                          Wave
+                        </Typography>
+                      </Stack>
+                    </Paper>
+                    <Paper className={classes.itemPaperContainer}>Item 1</Paper>
+                    <Paper className={classes.itemPaperContainer}>Item 1</Paper>
+                  </Stack>
                 </Box>
               </Box>
             </Card>


### PR DESCRIPTION
### 🧐 어떤 것을 변경했어요~?
효과음 세부 페이지 레이아웃을 피그마 디자인 기반으로 수정했습니다.
* 기본 sound Wave에 검은 테두리를 추가했습니다.
* sound Wave 오른쪽 밑에 전체 sound 기간을 추가했습니다.
* sound Wave 왼쪽 밑에 현재 sound 시간을 추가했습니다.
* 제목 아래에 일단 현재 다운로드 횟수를 추가했습니다. (이건 삭제할 수도 있을 듯)
* 현재 다운로드 횟수 아래에 태그를 추가했습니다.
* 제목 오른쪽에 다룬로드 버튼을 추가했습니다.
* 본문 맨 아래에 해당 소리의 정보를 담는 paper를 구현했습니다.
* 본문 오른쪽에 relative sound 나오는 로직을 변경했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
* 전체 sound기간은 wavesurfer 객체의 `getDuration`함수를 사용했습니다.
* 현재 sound시간은 wavesurfer 객체의 기능중 다음 코드를 사용해서 구현했습니다. 
```javascript
wavesurfer.current.on('audioprocess', () => {
        if (setCurrentTime) {
          setCurrentTime(wavesurfer.current.getCurrentTime());
        }
      });
```
* 다운로드 기능은 html의 a태그 원소를 임시로 DOM 트리에 넣고 삭제하는 방식으로 구현했습니다.
* relative sound를 기존에는 단순히 id로만 비교한 것을 이제는 서버랑 API통신을 해서 구현했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
* 서버랑 API 통신하는 useEffect 코드를 보시면 제가 왜 이렇게 작성했는지 아직도 잘 모르는 고민의 흔적을 확인할 수 있습니다.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="1109" alt="image" src="https://github.com/2024-1-CapstoneDesign/ses_website/assets/52999093/5c6df008-5e29-4b3e-b376-66f9d6ee9bfb">
<img width="792" alt="image" src="https://github.com/2024-1-CapstoneDesign/ses_website/assets/52999093/ee1851f1-5404-42db-92ba-c377a984d39f">
<img width="1107" alt="image" src="https://github.com/2024-1-CapstoneDesign/ses_website/assets/52999093/5bbd148e-afaf-45a8-b2f4-29705deb4c5e">
