### PR TITLE
[FEAT] main soundList에 Pagination 기능 추가

### DIFF
--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -112,6 +112,7 @@ function Main(props) {
   const [soundListPosts, setSoundListPosts] = useState([]);
   const [dialogOpen, setDialogOpen] = useState(null);
   const [isCookieRulesDialogOpen, setIsCookieRulesDialogOpen] = useState(false);
+  const [page, setPage] = useState(0);
 
   const selectHome = useCallback(() => {
     smoothScrollTop();
@@ -157,7 +158,7 @@ function Main(props) {
   }, [setDialogOpen]);
 
   const fetchSoundList = async () => {
-    const url = "https://soundeffect-search.p-e.kr/api/v1/soundeffect?page=0&size=5"
+    const url = `https://soundeffect-search.p-e.kr/api/v1/soundeffect?page=${page}&size=5`
     // const url = "https://soundeffect-search.p-e.kr/api/v1/soundeffect"
     try {
       const axiosRes = await axios.get(url);
@@ -207,7 +208,8 @@ function Main(props) {
       return soundListPost;
     });
     setSoundListPosts(soundListPosts);
-  }, [setSoundListPosts]);
+    selectSoundList()
+  }, [setSoundListPosts, page]);
 
   const handleCookieRulesDialogOpen = useCallback(() => {
     setIsCookieRulesDialogOpen(true);
@@ -252,6 +254,7 @@ function Main(props) {
         selectHome={selectHome}
         selectSoundList={selectSoundList}
         setSoundListPosts={setSoundListPosts}
+        setPage={setPage}
       />
       <Footer />
     </div>

--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -15,6 +15,8 @@ import {Typography} from "@mui/material";
 
 AOS.init({ once: true });
 
+const PAGESIZE = 10;
+
 const content = (
   <Fragment>
     <Typography variant="h6" paragraph>
@@ -158,7 +160,7 @@ function Main(props) {
   }, [setDialogOpen]);
 
   const fetchSoundList = async () => {
-    const url = `https://soundeffect-search.p-e.kr/api/v1/soundeffect?page=${page}&size=5`
+    const url = `https://soundeffect-search.p-e.kr/api/v1/soundeffect?page=${page}&size=${PAGESIZE}`
     // const url = "https://soundeffect-search.p-e.kr/api/v1/soundeffect"
     try {
       const axiosRes = await axios.get(url);

--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -157,7 +157,8 @@ function Main(props) {
   }, [setDialogOpen]);
 
   const fetchSoundList = async () => {
-    const url = "https://soundeffect-search.p-e.kr/api/v1/soundeffect"
+    const url = "https://soundeffect-search.p-e.kr/api/v1/soundeffect?page=0&size=5"
+    // const url = "https://soundeffect-search.p-e.kr/api/v1/soundeffect"
     try {
       const axiosRes = await axios.get(url);
       const resData = axiosRes.data; //fetchResult
@@ -176,7 +177,8 @@ function Main(props) {
             soundSnippet: "this is sound",
             soundCreateAt: 1576281600,
             soundContents: content,
-            soundVisible: true
+            soundVisible: true,
+            pageCnt: resData.data.totalPages
           }
         });
       }

--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -162,7 +162,7 @@ function Main(props) {
       const axiosRes = await axios.get(url);
       const resData = axiosRes.data; //fetchResult
       if (resData.result === "SUCCESS"){
-        return resData.data.map((soundEffect) => {
+        return resData.data.soundEffectDtos.map((soundEffect) => {
           return {
             soundId: soundEffect.soundEffectId,
             soundName: soundEffect.soundEffectName,

--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -211,6 +211,7 @@ function Main(props) {
     });
     setSoundListPosts(soundListPosts);
     selectSoundList()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setSoundListPosts, page]);
 
   const handleCookieRulesDialogOpen = useCallback(() => {

--- a/src/logged_out/components/Routing.js
+++ b/src/logged_out/components/Routing.js
@@ -8,7 +8,7 @@ import SoundListPost from "./soundList/SoundListPost";
 import useLocationBlocker from "../../shared/functions/useLocationBlocker";
 
 function Routing(props) {
-  const { soundListPosts, setSoundListPosts, selectSoundList, selectHome } = props;
+  const { soundListPosts, setSoundListPosts, selectSoundList, selectHome, setPage } = props;
   useLocationBlocker();
   return (
     <Switch>
@@ -33,6 +33,7 @@ function Routing(props) {
         selectSoundList={selectSoundList}
         soundListPosts={soundListPosts}
         setSoundListPosts={setSoundListPosts}
+        setPage={setPage}
       />
       <PropsRoute path="/" component={Home} selectHome={selectHome} />
     </Switch>

--- a/src/logged_out/components/home/FeatureSection.js
+++ b/src/logged_out/components/home/FeatureSection.js
@@ -18,7 +18,7 @@ const fetchSoundList = async () => {
     const axiosRes = await axios.get(url);
     const resData = axiosRes.data; //fetchResult
     if (resData.result === "SUCCESS"){
-      const resSoundList = resData.data.map(({soundEffectId, soundEffectName, soundEffectTags, soundEffectTypes}, idx) => {
+      const resSoundList = resData.data.soundEffectDtos.map(({soundEffectId, soundEffectName, soundEffectTags, soundEffectTypes}, idx) => {
         return {
           soundId: soundEffectId,
           soundName: soundEffectName,

--- a/src/logged_out/components/soundList/SoundList.js
+++ b/src/logged_out/components/soundList/SoundList.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, {useCallback, useEffect, useState} from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import {Grid, Box, Pagination} from "@mui/material";
@@ -6,6 +6,7 @@ import withStyles from "@mui/styles/withStyles";
 import SoundListCard from "./SoundListCard";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import MySideBar from "../home/MySideBar";
+import axios from "axios";
 
 const styles = (theme) => ({
   blogContentWrapper: {
@@ -68,7 +69,10 @@ function getVerticalSoundListPosts(isWidthUpSm, isWidthUpMd, soundListPosts) {
 }
 
 function SoundList(props) {
-  const { classes, soundListPosts, setSoundListPosts,  selectSoundList, theme } = props;
+  const { classes, soundListPosts, setSoundListPosts,  selectSoundList, setPage, theme } = props;
+  const handleChange = (event, value) => {
+    setPage(value - 1);
+  };
 
   const isWidthUpSm = useMediaQuery(theme.breakpoints.up("sm"));
   const isWidthUpMd = useMediaQuery(theme.breakpoints.up("md"));
@@ -77,11 +81,7 @@ function SoundList(props) {
 
   useEffect(() => {
     selectSoundList();
-  }, [selectSoundList]);
-
-  const handleChange = (event, page) => {
-    console.log(page);
-  }
+  }, [selectSoundList, totalPages]);
 
   return (
     <Box
@@ -100,9 +100,9 @@ function SoundList(props) {
         </Grid>
         {totalPages &&
           <Pagination
-          count={totalPages}
-          color="primary"
-          onChange={handleChange}
+            count={totalPages}
+            color="primary"
+            onChange={handleChange}
           />
         }
       </div>

--- a/src/logged_out/components/soundList/SoundList.js
+++ b/src/logged_out/components/soundList/SoundList.js
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from "react";
+import React, {useEffect} from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import {Grid, Box, Pagination} from "@mui/material";
@@ -6,7 +6,6 @@ import withStyles from "@mui/styles/withStyles";
 import SoundListCard from "./SoundListCard";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import MySideBar from "../home/MySideBar";
-import axios from "axios";
 
 const styles = (theme) => ({
   blogContentWrapper: {

--- a/src/logged_out/components/soundList/SoundList.js
+++ b/src/logged_out/components/soundList/SoundList.js
@@ -98,13 +98,15 @@ function SoundList(props) {
         <Grid container spacing={3}>
           {getVerticalSoundListPosts(isWidthUpSm, isWidthUpMd, soundListPosts)}
         </Grid>
-        {totalPages &&
-          <Pagination
-            count={totalPages}
-            color="primary"
-            onChange={handleChange}
-          />
-        }
+        <Box sx={{display: 'flex', justifyContent: 'center'}} mt={3}>
+          {totalPages &&
+            <Pagination
+              count={totalPages}
+              color="primary"
+              onChange={handleChange}
+            />
+          }
+        </Box>
       </div>
     </Box>
   );

--- a/src/logged_out/components/soundList/SoundList.js
+++ b/src/logged_out/components/soundList/SoundList.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
-import { Grid, Box } from "@mui/material";
+import {Grid, Box, Pagination} from "@mui/material";
 import withStyles from "@mui/styles/withStyles";
 import SoundListCard from "./SoundListCard";
 import useMediaQuery from "@mui/material/useMediaQuery";
@@ -73,9 +73,15 @@ function SoundList(props) {
   const isWidthUpSm = useMediaQuery(theme.breakpoints.up("sm"));
   const isWidthUpMd = useMediaQuery(theme.breakpoints.up("md"));
 
+  const totalPages = soundListPosts[0]?.pageCnt
+
   useEffect(() => {
     selectSoundList();
   }, [selectSoundList]);
+
+  const handleChange = (event, page) => {
+    console.log(page);
+  }
 
   return (
     <Box
@@ -92,6 +98,13 @@ function SoundList(props) {
         <Grid container spacing={3}>
           {getVerticalSoundListPosts(isWidthUpSm, isWidthUpMd, soundListPosts)}
         </Grid>
+        {totalPages &&
+          <Pagination
+          count={totalPages}
+          color="primary"
+          onChange={handleChange}
+          />
+        }
       </div>
     </Box>
   );


### PR DESCRIPTION
### 🧐 어떤 것을 변경했어요~?
* main soundList Page에 페이지네이션 기능을 추가했습니다.
* main soundList Page 하단에 페이지네이션 컴포넌트를 추가했습니다.
* 항상 전체 리스트를 받아오는 구조를 페이지네이션에 맞게 수정했습니다.
* 갑작스럽게 생겨난 DTO 구조에 맞춰서 코드를 수정했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
* 전체 리스트를 받아오는 파일인 Main.js에 페이지네이션이 반영된 API를 호출합니다.
* Main.js에 page useState를 사용합니다.
* Main.js에서 정의한 setState함수를 페이지네이션 컴포넌트가 있는 함수까지 가지고 내려가서 변경을 감지한 이후, 재 렌더링을 수행해서 기능을 구현합니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
이거 만드니까 조금 재밌어지는데 이것도 잠깐뿐이겠죠?

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
![image](https://github.com/2024-1-CapstoneDesign/ses_website/assets/52999093/6d8c3ea5-d9bb-4906-b8fb-7a110b25943b)
![image](https://github.com/2024-1-CapstoneDesign/ses_website/assets/52999093/46b4089e-91a3-4f24-915d-d2d9475851e0)