### PR TITLE
[FIX] 페이지네이션 값이 바뀌지 않음

### DIFF
--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -258,6 +258,7 @@ function Main(props) {
         selectSoundList={selectSoundList}
         setSoundListPosts={setSoundListPosts}
         setPage={setPage}
+        page={page}
       />
       <Footer />
     </div>

--- a/src/logged_out/components/Routing.js
+++ b/src/logged_out/components/Routing.js
@@ -8,7 +8,7 @@ import SoundListPost from "./soundList/SoundListPost";
 import useLocationBlocker from "../../shared/functions/useLocationBlocker";
 
 function Routing(props) {
-  const { soundListPosts, setSoundListPosts, selectSoundList, selectHome, setPage } = props;
+  const { soundListPosts, setSoundListPosts, selectSoundList, selectHome, setPage, page } = props;
   useLocationBlocker();
   return (
     <Switch>
@@ -34,6 +34,7 @@ function Routing(props) {
         soundListPosts={soundListPosts}
         setSoundListPosts={setSoundListPosts}
         setPage={setPage}
+        page={page}
       />
       <PropsRoute path="/" component={Home} selectHome={selectHome} />
     </Switch>

--- a/src/logged_out/components/soundList/SoundList.js
+++ b/src/logged_out/components/soundList/SoundList.js
@@ -68,7 +68,7 @@ function getVerticalSoundListPosts(isWidthUpSm, isWidthUpMd, soundListPosts) {
 }
 
 function SoundList(props) {
-  const { classes, soundListPosts, setSoundListPosts,  selectSoundList, setPage, theme } = props;
+  const { classes, soundListPosts, setSoundListPosts,  selectSoundList, setPage, theme, page } = props;
   const handleChange = (event, value) => {
     setPage(value - 1);
   };
@@ -103,6 +103,7 @@ function SoundList(props) {
               count={totalPages}
               color="primary"
               onChange={handleChange}
+              page={page + 1}
             />
           }
         </Box>

--- a/src/logged_out/components/soundList/SoundList.js
+++ b/src/logged_out/components/soundList/SoundList.js
@@ -104,6 +104,8 @@ function SoundList(props) {
               color="primary"
               onChange={handleChange}
               page={page + 1}
+              siblingCount={5}
+              boundaryCount={3}
             />
           }
         </Box>


### PR DESCRIPTION
### 🧐 어떤 것을 변경했어요~?
mui의 페이지네이션 컴포넌트가 정상적으로 작동하지 않은 것을 해결합니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
* 페이지네이션 컴포넌트의 page원소를 추가해서 페이지를 컨트롤 합니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
* 버그가 쉽게 잡혀서 다행입니다.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="1019" alt="image" src="https://github.com/2024-1-CapstoneDesign/ses_website/assets/52999093/a18999d9-bd03-42b8-a459-73234915099b">
