### PR TITLE
[FEAT] 랜딩 페이지 디자인 개선

### DIFF
--- a/src/logged_out/components/home/FeatureSection.js
+++ b/src/logged_out/components/home/FeatureSection.js
@@ -58,8 +58,11 @@ function FeatureSection(props) {
   return (
     <div style={{ backgroundColor: theme.palette.background.default }}>
       <div className="container-fluid lg-p-top">
-        <Typography variant="h3" align="center" className="lg-mg-bottom">
-          SoundList
+        <Typography
+          variant="h3" align="center" className="lg-mg-bottom"
+          sx={{fontFamily: "'Orbitron', cursive", fontWeight: 'bold'}}
+        >
+          Today's SoundEffect
         </Typography>
         {isLoading && <strong>Loading....</strong>}
         {isError && <strong>{response?.errorMessage}</strong>}

--- a/src/logged_out/components/home/HeadSection.js
+++ b/src/logged_out/components/home/HeadSection.js
@@ -124,7 +124,7 @@ function HeadSection(props) {
                       <Box mb={4}>
                         <Typography
                           variant={isWidthUpLg ? "h3" : "h4"}
-                          sx={{fontFamily: "'Orbitron', cursive"}}
+                          sx={{fontFamily: "'Orbitron', cursive", fontWeight: "bold"}}
                         >
                           Are you ready for a revolution in finding sound effects?
                         </Typography>
@@ -163,9 +163,13 @@ function HeadSection(props) {
                           className={classes.extraLargeButton}
                           classes={{ label: classes.extraLargeButtonLabel }}
                           onClick={handleModalOpen}
-                          // href="https://github.com/dunky11/react-saas-template"
                         >
-                          Start Searching Side Effect sound
+                          <Typography
+                            variant={isWidthUpLg ? "h4" : "h5"}
+                            sx={{fontFamily: "'Orbitron', cursive", fontWeight: "bold"}}
+                          >
+                            let's Search!
+                          </Typography>
                         </Button>
                       </div>
                     </Box>

--- a/src/logged_out/components/home/HeadSection.js
+++ b/src/logged_out/components/home/HeadSection.js
@@ -135,8 +135,7 @@ function HeadSection(props) {
                       justifyContent="space-between"
                       height="100%"
                     >
-                      <div>
-                        <Box mb={2}>
+                        <Box mb={2} sx={{flexGrow: 1, display: "flex", flexDirection: "column", justifyContent: "center"}}>
                           <Typography
                             variant={isWidthUpLg ? "h6" : "body1"}
                             color="textSecondary"
@@ -162,6 +161,7 @@ function HeadSection(props) {
                             Let’s experience the full sound effects of Aulo!
                           </Typography>
                         </Box>
+                      <div>
                         <Button
                           variant="contained"
                           color="primary"

--- a/src/logged_out/components/home/HeadSection.js
+++ b/src/logged_out/components/home/HeadSection.js
@@ -122,8 +122,11 @@ function HeadSection(props) {
                       height="100%"
                     >
                       <Box mb={4}>
-                        <Typography variant={isWidthUpLg ? "h3" : "h4"}>
-                          You can find all the sound effects you want.
+                        <Typography
+                          variant={isWidthUpLg ? "h3" : "h4"}
+                          sx={{fontFamily: "'Orbitron', cursive"}}
+                        >
+                          Are you ready for a revolution in finding sound effects?
                         </Typography>
                       </Box>
                       <div>
@@ -132,8 +135,25 @@ function HeadSection(props) {
                             variant={isWidthUpLg ? "h6" : "body1"}
                             color="textSecondary"
                           >
-                            Lorem ipsum dolor sit amet, consetetur sadipscing
-                            elitr, sed diam nonumy eirmod tempor invidunt
+                            you can find all the sound effects you want.
+                          </Typography>
+                          <Typography
+                            variant={isWidthUpLg ? "h6" : "body1"}
+                            color="textSecondary"
+                          >
+                            Just put in Youtube url and section.
+                          </Typography>
+                          <Typography
+                            variant={isWidthUpLg ? "h6" : "body1"}
+                            color="textSecondary"
+                          >
+                            That’s how to search for sound effects.
+                          </Typography>
+                          <Typography
+                            variant={isWidthUpLg ? "h6" : "body1"}
+                            color="textSecondary"
+                          >
+                            Let’s experience the full sound effects of Aulo!
                           </Typography>
                         </Box>
                         <Button

--- a/src/logged_out/components/home/HeadSection.js
+++ b/src/logged_out/components/home/HeadSection.js
@@ -114,7 +114,7 @@ function HeadSection(props) {
             >
               <div className={classNames(classes.containerFix, "container")}>
                 <Box justifyContent="space-between" className="row">
-                  <Box mb={4}>
+                  <Box mb={4} sx={{width: "100%"}}>
                     <Typography
                       variant={isWidthUpLg ? "h3" : "h4"}
                       sx={{fontFamily: "'Orbitron', cursive", fontWeight: "bold"}}

--- a/src/logged_out/components/home/HeadSection.js
+++ b/src/logged_out/components/home/HeadSection.js
@@ -158,7 +158,7 @@ function HeadSection(props) {
                         </Box>
                         <Button
                           variant="contained"
-                          color="secondary"
+                          color="primary"
                           fullWidth
                           className={classes.extraLargeButton}
                           classes={{ label: classes.extraLargeButtonLabel }}

--- a/src/logged_out/components/home/HeadSection.js
+++ b/src/logged_out/components/home/HeadSection.js
@@ -114,6 +114,20 @@ function HeadSection(props) {
             >
               <div className={classNames(classes.containerFix, "container")}>
                 <Box justifyContent="space-between" className="row">
+                  <Box mb={4}>
+                    <Typography
+                      variant={isWidthUpLg ? "h3" : "h4"}
+                      sx={{fontFamily: "'Orbitron', cursive", fontWeight: "bold"}}
+                    >
+                      Are you ready for a revolution
+                    </Typography>
+                    <Typography
+                      variant={isWidthUpLg ? "h3" : "h4"}
+                      sx={{fontFamily: "'Orbitron', cursive", fontWeight: "bold"}}
+                    >
+                      in finding sound effects?
+                    </Typography>
+                  </Box>
                   <Grid item xs={12} md={5}>
                     <Box
                       display="flex"
@@ -121,14 +135,6 @@ function HeadSection(props) {
                       justifyContent="space-between"
                       height="100%"
                     >
-                      <Box mb={4}>
-                        <Typography
-                          variant={isWidthUpLg ? "h3" : "h4"}
-                          sx={{fontFamily: "'Orbitron', cursive", fontWeight: "bold"}}
-                        >
-                          Are you ready for a revolution in finding sound effects?
-                        </Typography>
-                      </Box>
                       <div>
                         <Box mb={2}>
                           <Typography


### PR DESCRIPTION
### 🧐 어떤 것을 변경했어요~?
랜딩페이지의 디자인을 개선합니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
* 기존 페이지의 레이아웃을 변경했습니다.
* 디자인 사진은 세로로 길어서 적용하면 디자인이 깨저보여서 가로로 긴 현재 사진을 그대로 사용했습니다. @hayeongKo , 다른 사진을 쓰고 싶으면 가로로 긴 사진이 필요해요
* today's soundList는 현상 유지 하는 것이 제 개인적인 생각으로는 좋은 것 같아서 일단 이렇게 했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
* 디자인 피드백 언제든 환영합니다.
* 피드백은 github 댓글로 받습니다.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="1429" alt="image" src="https://github.com/2024-1-CapstoneDesign/ses_website/assets/52999093/4492b95d-89e7-44e8-aa5b-c8b8bf9a40c6">
<img width="1422" alt="image" src="https://github.com/2024-1-CapstoneDesign/ses_website/assets/52999093/ba217b83-d58e-4191-b02d-1e363c49f54e">
