### PR TITLE
[FEAT] 효과음 텍스트 검색 기능 추가하기

### DIFF
--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -101,44 +101,44 @@ function Main(props) {
     filterList.forEach((filter, index) => {
       switch (index){
         case 0:
-          if (filter !== 0){
+          if (filter !== 0 && filter !== undefined){
             resObj.name = filter.value;
           }
           break;
         case 1:
-          if (filter !== 0){
+          if (filter !== 0 && filter !== undefined && filter.value !== undefined){
             resObj.type = filter.value[0];
           }
           break;
         case 2:
-          if (filter !== 0){
+          if (filter !== 0 && filter !== undefined && filter.value !== undefined){
             resObj.fromLen = filter.value[0];
             resObj.toLen = filter.value[1];
           }
           break;
         case 3:
-          if (filter !== 0){
+          if (filter !== 0 && filter !== undefined && filter.value !== undefined){
             resObj.fromFileSize = filter.value[0];
             resObj.toFileSize = filter.value[1];
           }
           break;
         case 4:
-          if (filter !== 0){
+          if (filter !== 0 && filter !== undefined && filter.value !== undefined){
             resObj.sampleRate = filter.value[0];
           }
           break;
         case 5:
-          if (filter !== 0){
+          if (filter !== 0 && filter !== undefined && filter.value !== undefined){
             resObj.bitDepth = filter.value[0];
           }
           break;
         case 6:
-          if (filter !== 0){
+          if (filter !== 0 && filter !== undefined && filter.value !== undefined){
             resObj.channels = filter.value[0];
           }
           break;
         case 7:
-          if (filter !== []){
+          if (filter !== [] && filter !== undefined){
             resObj.soundEffectTagId = filter.join();
           }
           break;

--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -35,7 +35,7 @@ function Main(props) {
   const [dialogOpen, setDialogOpen] = useState(null);
   const [isCookieRulesDialogOpen, setIsCookieRulesDialogOpen] = useState(false);
   const [page, setPage] = useState(0);
-  const [filterList, setFilterList] = useState([0, 0, 0, 0, 0, 0, []]);
+  const [filterList, setFilterList] = useState([0, 0, 0, 0, 0, 0, 0, []]);
 
   const selectHome = useCallback(() => {
     smoothScrollTop();
@@ -99,39 +99,39 @@ function Main(props) {
     };
     filterList.forEach((filter, index) => {
       switch (index){
-        case 0:
+        case 1:
           if (filter !== 0){
             resObj.type = filter.value[0];
           }
           break;
-        case 1:
+        case 2:
           if (filter !== 0){
             resObj.fromLen = filter.value[0];
             resObj.toLen = filter.value[1];
           }
           break;
-        case 2:
+        case 3:
           if (filter !== 0){
             resObj.fromFileSize = filter.value[0];
             resObj.toFileSize = filter.value[1];
           }
           break;
-        case 3:
+        case 4:
           if (filter !== 0){
             resObj.sampleRate = filter.value[0];
           }
           break;
-        case 4:
+        case 5:
           if (filter !== 0){
             resObj.bitDepth = filter.value[0];
           }
           break;
-        case 5:
+        case 6:
           if (filter !== 0){
             resObj.channels = filter.value[0];
           }
           break;
-        case 6:
+        case 7:
           if (filter !== []){
             resObj.soundEffectTagId = filter.join();
           }

--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -224,7 +224,7 @@ function Main(props) {
         setFilterList([0, 0, 0, 0, 0, 0, []]);
       }
     }
-  }, [location, history]);
+  }, [location, history, filterList]);
 
   return (
     <div className={classes.wrapper}>

--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -96,9 +96,15 @@ function Main(props) {
       sampleRate: "",
       bitDepth: "",
       channels: "",
+      name: "",
     };
     filterList.forEach((filter, index) => {
       switch (index){
+        case 0:
+          if (filter !== 0){
+            resObj.name = filter.value;
+          }
+          break;
         case 1:
           if (filter !== 0){
             resObj.type = filter.value[0];
@@ -143,12 +149,12 @@ function Main(props) {
 
   const fetchSoundList = async () => {
     const {type, fromLen, toLen, fromFileSize, toFileSize,
-      sampleRate, bitDepth, channels, soundEffectTagId} = getURLQueryString(filterList);
+      sampleRate, bitDepth, channels, soundEffectTagId, name} = getURLQueryString(filterList);
     let url;
     if (soundEffectTagId){
-      url = `https://soundeffect-search.p-e.kr/api/v1/soundeffect?type=${type}&fromLength=${fromLen}&toLength=${toLen}&fromFileSize=${fromFileSize}&toFileSize=${toFileSize}&sampleRate=${sampleRate}&bitDepth=${bitDepth}&channels=${channels}&soundEffectTagId=${soundEffectTagId}&page=${page}&size=${PAGESIZE}`
+      url = `https://soundeffect-search.p-e.kr/api/v1/soundeffect?type=${type}&fromLength=${fromLen}&toLength=${toLen}&fromFileSize=${fromFileSize}&toFileSize=${toFileSize}&sampleRate=${sampleRate}&bitDepth=${bitDepth}&channels=${channels}&name=${name}&soundEffectTagId=${soundEffectTagId}&page=${page}&size=${PAGESIZE}`
     } else {
-      url = `https://soundeffect-search.p-e.kr/api/v1/soundeffect?type=${type}&fromLength=${fromLen}&toLength=${toLen}&fromFileSize=${fromFileSize}&toFileSize=${toFileSize}&sampleRate=${sampleRate}&bitDepth=${bitDepth}&channels=${channels}&page=${page}&size=${PAGESIZE}`
+      url = `https://soundeffect-search.p-e.kr/api/v1/soundeffect?type=${type}&fromLength=${fromLen}&toLength=${toLen}&fromFileSize=${fromFileSize}&toFileSize=${toFileSize}&sampleRate=${sampleRate}&bitDepth=${bitDepth}&channels=${channels}&name=${name}&page=${page}&size=${PAGESIZE}`
     }
     try {
       const axiosRes = await axios.get(url);

--- a/src/logged_out/components/home/MySearchField.js
+++ b/src/logged_out/components/home/MySearchField.js
@@ -2,6 +2,7 @@ import withStyles from "@mui/styles/withStyles";
 import {alpha} from "@mui/material";
 import SearchIcon from '@mui/icons-material/Search';
 import InputBase from '@mui/material/InputBase';
+import React, {useEffect, useState} from "react";
 
 const styles = (theme) => ({
   searchContainer: {
@@ -49,7 +50,25 @@ const styles = (theme) => ({
 
 
 function MySearchField(props) {
-  const {classes} = props;
+  const {classes, filterList, setFilterList, selectSoundList} = props;
+  const [value, setValue] = useState('');
+
+  const handleChange = (e) => {
+    const newFilterList = [...filterList];
+    newFilterList[0] = {
+      value: e.target.value,
+    }
+    setFilterList(newFilterList);
+  };
+
+  useEffect(() => {
+    selectSoundList()
+  }, [selectSoundList]);
+
+  useEffect(() => {
+    setValue(filterList[0].value);
+  }, [filterList]);
+
   return (
     <div className={classes.searchContainer}>
       <div className={classes.searchIconWrapper}>
@@ -59,6 +78,8 @@ function MySearchField(props) {
         className={classes.searchInput}
         placeholder={"Search..."}
         inputProps={{'aria-label': 'search'}}
+        value={value}
+        onChange={handleChange}
       />
     </div>
   );

--- a/src/logged_out/components/home/MySearchField.js
+++ b/src/logged_out/components/home/MySearchField.js
@@ -1,0 +1,67 @@
+import withStyles from "@mui/styles/withStyles";
+import {alpha} from "@mui/material";
+import SearchIcon from '@mui/icons-material/Search';
+import InputBase from '@mui/material/InputBase';
+
+const styles = (theme) => ({
+  searchContainer: {
+    position: 'relative',
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: alpha(theme.palette.common.white, 0.15),
+    '&:hover': {
+      backgroundColor: alpha(theme.palette.common.white, 0.25),
+    },
+    marginLeft: 0,
+    width: '100%',
+    [theme.breakpoints.up('sm')]: {
+      marginLeft: theme.spacing(1),
+      marginRight: theme.spacing(1),
+      width: 'auto',
+    },
+    border: "1px solid rgba(0, 0, 0, 0.12)",
+  },
+  searchIconWrapper: {
+    padding: theme.spacing(0, 2),
+    height: '100%',
+    position: 'absolute',
+    pointerEvents: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  searchInput: {
+    color: 'inherit',
+    width: '100%',
+    '& .MuiInputBase-input': {
+      padding: theme.spacing(1, 1, 1, 0),
+      // vertical padding + font size from searchIcon
+      paddingLeft: `calc(1em + ${theme.spacing(4)})`,
+      transition: theme.transitions.create('width'),
+      [theme.breakpoints.up('sm')]: {
+        width: '12ch',
+        '&:focus': {
+          width: '20ch',
+        },
+      },
+    },
+  }
+});
+
+
+function MySearchField(props) {
+  const {classes} = props;
+  return (
+    <div className={classes.searchContainer}>
+      <div className={classes.searchIconWrapper}>
+        <SearchIcon/>
+      </div>
+      <InputBase
+        className={classes.searchInput}
+        placeholder={"Search..."}
+        inputProps={{'aria-label': 'search'}}
+      />
+    </div>
+  );
+}
+
+export default withStyles(styles, { withTheme: true })(MySearchField);

--- a/src/logged_out/components/home/MySideBar.js
+++ b/src/logged_out/components/home/MySideBar.js
@@ -4,6 +4,7 @@ import { withStyles } from "@mui/styles";
 import { Box, Typography, Chip } from "@mui/material";
 import ButtonBase from "@mui/material/ButtonBase";
 import MySidebarElement from "./MySidebarElement";
+import MySearchField from "./MySearchField";
 
 function shadeColor(color, percent) {
 
@@ -286,6 +287,7 @@ function MySideBar(props) {
 
   return ( //type, duration, filesize, sample rate, bit depth, channels
     <Box className={classes.sidebarContainer}>
+      <MySearchField />
       <MySidebarElement
         elementName={"Type"}
         elementList={typeElementList}

--- a/src/logged_out/components/home/MySideBar.js
+++ b/src/logged_out/components/home/MySideBar.js
@@ -287,7 +287,12 @@ function MySideBar(props) {
 
   return ( //type, duration, filesize, sample rate, bit depth, channels
     <Box className={classes.sidebarContainer}>
-      <MySearchField id={0}/>
+      <MySearchField
+        id={0}
+        filterList={filterList}
+        setFilterList={setFilterList}
+        selectSoundList={selectSoundList}
+      />
       <MySidebarElement
         elementName={"Type"}
         elementList={typeElementList}

--- a/src/logged_out/components/home/MySideBar.js
+++ b/src/logged_out/components/home/MySideBar.js
@@ -123,7 +123,7 @@ function MySideBar(props) {
 
   const handleChipClick = ({tagName, tagId}) => {
     const newFilterList = [...filterList];
-    const newSelectedTagIds = new Set(filterList[6]);
+    const newSelectedTagIds = new Set(filterList[7]);
     const newSelectedTags = new Set(selectedTags);
     if (selectedTags.has(tagName)) {
       newSelectedTags.delete(tagName);
@@ -133,7 +133,7 @@ function MySideBar(props) {
       newSelectedTagIds.add(tagId);
     }
     setSelectedTags(newSelectedTags);
-    newFilterList[6] = [...newSelectedTagIds];
+    newFilterList[7] = [...newSelectedTagIds];
     setFilterList(newFilterList);
   };
   const typeElementList = [
@@ -160,7 +160,7 @@ function MySideBar(props) {
   ].map(element => {
     return {
       ...element,
-      id: 0,
+      id: 1,
     }
   });
 
@@ -188,7 +188,7 @@ function MySideBar(props) {
   ].map(element => {
     return {
       ...element,
-      id: 1,
+      id: 2,
     }
   });
 
@@ -216,7 +216,7 @@ function MySideBar(props) {
   ].map(element => {
     return {
       ...element,
-      id: 2,
+      id: 3,
     }
   });
 
@@ -244,7 +244,7 @@ function MySideBar(props) {
   ].map(element => {
     return {
       ...element,
-      id: 3,
+      id: 4,
     }
   });
 
@@ -268,7 +268,7 @@ function MySideBar(props) {
   ].map(element => {
     return {
       ...element,
-      id: 4,
+      id: 5,
     }
   });
 
@@ -280,14 +280,14 @@ function MySideBar(props) {
   ].map(element => {
     return {
       ...element,
-      id: 5,
+      id: 6,
     }
   });
 
 
   return ( //type, duration, filesize, sample rate, bit depth, channels
     <Box className={classes.sidebarContainer}>
-      <MySearchField />
+      <MySearchField id={0}/>
       <MySidebarElement
         elementName={"Type"}
         elementList={typeElementList}

--- a/src/logged_out/components/home/MySideBar.js
+++ b/src/logged_out/components/home/MySideBar.js
@@ -288,7 +288,6 @@ function MySideBar(props) {
   return ( //type, duration, filesize, sample rate, bit depth, channels
     <Box className={classes.sidebarContainer}>
       <MySearchField
-        id={0}
         filterList={filterList}
         setFilterList={setFilterList}
         selectSoundList={selectSoundList}

--- a/src/logged_out/components/home/MySidebarElement.js
+++ b/src/logged_out/components/home/MySidebarElement.js
@@ -49,6 +49,13 @@ function MySidebarElement(props) {
 
   useEffect(() => {
     selectSoundList();
+    const newChecked = [...checked];
+    elementList.forEach((element, index) => {
+      if (JSON.stringify(element) === JSON.stringify(filterList[elementList[index].id])){
+        newChecked[index] = true;
+      }
+    });
+    setChecked(newChecked);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectSoundList]);
 


### PR DESCRIPTION
### 🧐 어떤 것을 변경했어요~?
* 효과음 텍스트 검색 기능을 추가했습니다.
* soundPage선택 이후 뒤로가기 했을때 필터링이 남아있지 않는 버그를 수정했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
* 효과음 텍스트 검색은 단순이 API를 받아서 처리 했습니다.
* 필터링이 남아있지 않는 버그는 useEffect를 사용해서 다시 랜더링 될 때, filteringList에 있는 값이랑 일치한 필터의 상태를 true로 바꿔서 해결했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
* 필터링때문에 이렇게 골치 아플줄 몰랐어요

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="1435" alt="image" src="https://github.com/2024-1-CapstoneDesign/ses_website/assets/52999093/10eeee73-5efa-4b24-a336-c8d3b65ad5c6">
