### PR TITLE
[FIX] 효과음 필터링 중에서 태그 필터링 버그 수정 

### DIFF
--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -142,6 +142,16 @@ function Main(props) {
             resObj.soundEffectTagId = filter.join();
           }
           break;
+        default:
+          resObj.type = "";
+          resObj.fromLen =  "";
+          resObj.toLen = "";
+          resObj.fromFileSize =  "";
+          resObj.toFileSize =  "";
+          resObj.sampleRate = "";
+          resObj.bitDepth = "";
+          resObj.channels = "";
+          resObj.name = "";
       }
     });
     return resObj;

--- a/src/logged_out/components/Main.js
+++ b/src/logged_out/components/Main.js
@@ -253,7 +253,7 @@ function Main(props) {
       />
       <NavBar
         selectedTab={selectedTab}
-        selectTab={setSelectedTab} // 여기서 확인하는듯
+        selectTab={setSelectedTab}
         openLoginDialog={openLoginDialog}
         openRegisterDialog={openRegisterDialog}
         mobileDrawerOpen={isMobileDrawerOpen}
@@ -265,7 +265,6 @@ function Main(props) {
         selectHome={selectHome}
         selectSoundList={selectSoundList}
         selectProfile={selectProfile}
-        setSoundListPosts={setSoundListPosts}
         setPage={setPage}
         page={page}
         filterList={filterList}

--- a/src/logged_out/components/Routing.js
+++ b/src/logged_out/components/Routing.js
@@ -9,7 +9,7 @@ import useLocationBlocker from "../../shared/functions/useLocationBlocker";
 import Profile from "./home/Profile";
 
 function Routing(props) {
-  const { soundListPosts, setSoundListPosts, selectSoundList, selectHome, selectProfile, setPage, page, filterList, setFilterList } = props;
+  const { soundListPosts, selectSoundList, selectHome, selectProfile, setPage, page, filterList, setFilterList } = props;
   useLocationBlocker();
   return (
     <Switch>
@@ -38,7 +38,6 @@ function Routing(props) {
         component={SoundList}
         selectSoundList={selectSoundList}
         soundListPosts={soundListPosts}
-        setSoundListPosts={setSoundListPosts}
         setPage={setPage}
         page={page}
         filterList={filterList}

--- a/src/logged_out/components/home/MySideBar.js
+++ b/src/logged_out/components/home/MySideBar.js
@@ -113,6 +113,7 @@ function MySideBar(props) {
         newSelectedTag.add(res.tagName);
     });
     setSelectedTags(newSelectedTag);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectSoundList]);
 
   const handleChipClick = ({tagName, tagId}) => {

--- a/src/logged_out/components/home/MySideBar.js
+++ b/src/logged_out/components/home/MySideBar.js
@@ -93,7 +93,7 @@ const styles = (theme) => ({
 });
 
 function MySideBar(props) {
-  const { classes, soundListPosts, selectSoundList, setSoundListPosts, filterList, setFilterList, setPage } = props;
+  const { classes, soundListPosts, selectSoundList, filterList, setFilterList, setPage } = props;
   const [selectedTags, setSelectedTags] = useState(new Set());
 
   const uniqueTagList = [
@@ -104,20 +104,8 @@ function MySideBar(props) {
     ).values()
   ];
 
-  const resetVisibility = () => {
-    const updatedSoundListPosts = soundListPosts.map(sound => {
-      return {
-        ...sound,
-        soundVisible: true
-      };
-    });
-    setSoundListPosts(updatedSoundListPosts);
-  }
-
   useEffect(() => {
     selectSoundList();
-    setSelectedTags(new Set());
-    resetVisibility();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectSoundList]);
 

--- a/src/logged_out/components/home/MySideBar.js
+++ b/src/logged_out/components/home/MySideBar.js
@@ -106,7 +106,13 @@ function MySideBar(props) {
 
   useEffect(() => {
     selectSoundList();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const newSelectedTag = new Set();
+    filterList[7].forEach(id => {
+      const res = uniqueTagList.find(({tagId}) => tagId === id);
+      if (res)
+        newSelectedTag.add(res.tagName);
+    });
+    setSelectedTags(newSelectedTag);
   }, [selectSoundList]);
 
   const handleChipClick = ({tagName, tagId}) => {

--- a/src/logged_out/components/soundList/SoundList.js
+++ b/src/logged_out/components/soundList/SoundList.js
@@ -68,8 +68,7 @@ function getVerticalSoundListPosts(isWidthUpSm, isWidthUpMd, soundListPosts) {
 }
 
 function SoundList(props) {
-  const { classes, soundListPosts, setSoundListPosts,
-      selectSoundList, setPage, theme, page, filterList, setFilterList } = props;
+  const { classes, soundListPosts, selectSoundList, setPage, theme, page, filterList, setFilterList } = props;
   const handleChange = (event, value) => {
     setPage(value - 1);
   };
@@ -92,7 +91,6 @@ function SoundList(props) {
       <MySideBar
         selectSoundList={selectSoundList}
         soundListPosts={soundListPosts}
-        setSoundListPosts={setSoundListPosts}
         filterList={filterList}
         setFilterList={setFilterList}
         setPage={setPage}


### PR DESCRIPTION
### 🧐 어떤 것을 변경했어요~?
태그 필터링 작동이 정상적으로 되지 않는 현상을 수정했습니다.
태그 필터링을 누르고 soundPost로 이동한 다음 다시 뒤로가기를 하면 필터링이 반영 안되는 현상을 수정합니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
* MySidebar.js에서 useEffect 함수 안에 기존 filtering값을 통해서 정보를 받아오는 로직을 추가했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
* 자바스크립트가 반환값을 못찾으면 에러를 출력하는게 아니라 undefined를 출력해서 버그 잡는데 좀 오랜 시간이 걸렸습니다.
