### PR TITLE
[FIX] 태그 필터링이 다른 페이지에서 작동하지 않는 문제 해결 

### DIFF
--- a/src/logged_out/components/home/InputModal.js
+++ b/src/logged_out/components/home/InputModal.js
@@ -171,7 +171,7 @@ const InputModal = (props) => {
 
       setProgress(true);
       setProgressValue(0);
-      setProgressSpeed(5);
+      setProgressSpeed(4);
       axios.post(
         "https://soundeffect-search.p-e.kr/api/v1/soundeffect/search", formData, axiosConfig
       ).then(response => {
@@ -222,7 +222,7 @@ const InputModal = (props) => {
 
         setProgress(true);
         setProgressValue(0);
-        setProgressSpeed(4);
+        setProgressSpeed(2);
         axios.get(
           `https://soundeffect-search.p-e.kr/api/v1/soundeffect/youtube?url=${youtubeURL}&from=${from}&to=${to}`, axiosConfig
         ).then(response => {

--- a/src/logged_out/components/home/MySearchField.js
+++ b/src/logged_out/components/home/MySearchField.js
@@ -50,7 +50,7 @@ const styles = (theme) => ({
 
 
 function MySearchField(props) {
-  const {classes, filterList, setFilterList, selectSoundList} = props;
+  const {classes, filterList, setFilterList, selectSoundList, setPage} = props;
   const [value, setValue] = useState('');
 
   const handleChange = (e) => {
@@ -59,6 +59,7 @@ function MySearchField(props) {
       value: e.target.value,
     }
     setFilterList(newFilterList);
+    setPage(0);
   };
 
   useEffect(() => {

--- a/src/logged_out/components/home/MySideBar.js
+++ b/src/logged_out/components/home/MySideBar.js
@@ -116,7 +116,6 @@ function MySideBar(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectSoundList]);
 
-  // http://localhost:3000/soundList/card/oh-hell-no
   const handleChipClick = ({tagName, tagId}) => {
     const newFilterList = [...filterList];
     const newSelectedTagIds = new Set(filterList[7]);
@@ -131,6 +130,7 @@ function MySideBar(props) {
     setSelectedTags(newSelectedTags);
     newFilterList[7] = [...newSelectedTagIds];
     setFilterList(newFilterList);
+    setPage(0);
   };
   const typeElementList = [
     {
@@ -287,6 +287,7 @@ function MySideBar(props) {
         filterList={filterList}
         setFilterList={setFilterList}
         selectSoundList={selectSoundList}
+        setPage={setPage}
       />
       <MySidebarElement
         elementName={"Type"}


### PR DESCRIPTION
태그 필터링을 할때 setPage(0)으로 해서 API 호출하는 방식으로 버그 수정했습니다.